### PR TITLE
Allow specific flags of Solana

### DIFF
--- a/programs/kfarms/Cargo.toml
+++ b/programs/kfarms/Cargo.toml
@@ -37,4 +37,9 @@ scope = { git = "https://github.com/Kamino-Finance/scope.git", package = "scope-
 bytemuck = { version = "1.4.0", features = ["min_const_generics", "derive"] }
 uint = "0.9.5"
 
-
+[lints.rust.unexpected_cfgs]
+check-cfg = [
+    'cfg(target_os, values("solana"))',
+    'cfg(feature, values("anchor-debug", "custom-heap", "custom-panic", "no-log-ix-name"))',
+]
+level = "warn"


### PR DESCRIPTION
The rust compiler does not recognize some `solana` or `anchor` names as valid candidates for `cfg` purposes.

![Capture d’écran depuis 2025-05-23 08-47-55](https://github.com/user-attachments/assets/984b837c-d4ff-4312-b5bd-00e0c443005d)

However, such a situation can be solved through the use of `unexpected_cfgs`, which is what this PR does.