### PR TITLE
Release 1.6.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "farms"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/kfarms/Cargo.toml
+++ b/programs/kfarms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "farms"
 description = "Kamino Farms"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 license = "BUSL-1.1"
 publish = false

--- a/programs/kfarms/src/farm_operations.rs
+++ b/programs/kfarms/src/farm_operations.rs
@@ -302,6 +302,31 @@ pub fn update_farm_config(
             xmsg!("prev value {:?}", farm_state.second_delegated_authority);
             farm_state.second_delegated_authority = pubkey;
         }
+        FarmConfigOption::UpdateIsRewardUserOnceEnabled => {
+            require!(farm_state.is_delegated(), FarmError::FarmNotDelegated);
+            let value: bool = BorshDeserialize::try_from_slice(&data[..1])?;
+            xmsg!("farm_operations::update_farm_config is_reward_user_once_enabled={value}",);
+            xmsg!("prev value {:?}", farm_state.is_reward_user_once_enabled);
+            farm_state.is_reward_user_once_enabled = value as u8;
+        }
+        FarmConfigOption::UpdateDelegatedAuthority => {
+            require!(farm_state.is_delegated(), FarmError::FarmNotDelegated);
+            let pubkey: Pubkey = BorshDeserialize::try_from_slice(data)?;
+            require_neq!(
+                pubkey,
+                Pubkey::default(),
+                FarmError::InvalidDelegatedAuthorityUpdate
+            );
+            xmsg!("farm_operations::update_farm_config delegated_authority={pubkey}",);
+            xmsg!("prev value {:?}", farm_state.delegate_authority);
+            farm_state.delegate_authority = pubkey;
+        }
+        FarmConfigOption::UpdateIsHarvestingPermissionless => {
+            let value: bool = BorshDeserialize::try_from_slice(&data[..1])?;
+            xmsg!("farm_operations::update_farm_config is_harvesting_permissionless={value}",);
+            xmsg!("prev value {:?}", farm_state.is_harvesting_permissionless);
+            farm_state.is_harvesting_permissionless = value as u8;
+        }
     };
     Ok(())
 }

--- a/programs/kfarms/src/lib.rs
+++ b/programs/kfarms/src/lib.rs
@@ -280,7 +280,7 @@ pub enum FarmError {
     #[msg("Authority must match farm delegate authority")]
     AuthorityFarmDelegateMissmatch,
    
-    #[msg("Farm not delegated, can not set stake")]
+    #[msg("Farm not delegated, can not complete operation")]
     FarmNotDelegated,
    
     #[msg("Operation not allowed for delegated farm")]
@@ -366,6 +366,18 @@ pub enum FarmError {
    
     #[msg("Invalid farm state deposit warmup period for transfer ownership, must be 0 if old user has stake")]
     InvalidTransferOwnershipFarmStateDepositWarmupPeriod,
+   
+    #[msg("Reward User Once feature is disabled")]
+    RewardUserOnceFeatureDisabled,
+   
+    #[msg("Can not set delegate_authority to default pubkey - farm is delegated")]
+    InvalidDelegatedAuthorityUpdate,
+   
+    #[msg("User token account owner does not match user state owner")]
+    UserTokenAccountOwnerMismatch,
+   
+    #[msg("Harvesting is not permissionless, payer does not match user state owner")]
+    HarvestingNotPermissionlessPayerMismatch,
 }
 
 impl From<DecimalError> for FarmError {

--- a/programs/kfarms/src/state.rs
+++ b/programs/kfarms/src/state.rs
@@ -99,7 +99,12 @@ pub struct FarmState {
 
     pub is_farm_delegated: u8,
 
-    pub _padding0: [u8; 5],
+
+    pub is_reward_user_once_enabled: u8,
+
+    pub is_harvesting_permissionless: u8,
+
+    pub _padding0: [u8; 3],
 
 
 
@@ -242,7 +247,10 @@ impl Default for FarmState {
             is_farm_frozen: 0,
             is_farm_delegated: 0,
 
-            _padding0: [0; 5],
+            is_reward_user_once_enabled: 0,
+            is_harvesting_permissionless: 0,
+
+            _padding0: [0; 3],
 
            
             withdraw_authority: Pubkey::default(),
@@ -669,6 +677,9 @@ pub enum FarmConfigOption {
     UpdateDelegatedRpsAdmin,
     UpdateVaultId,
     UpdateExtraDelegatedAuthority,
+    UpdateIsRewardUserOnceEnabled,
+    UpdateDelegatedAuthority,
+    UpdateIsHarvestingPermissionless,
 }
 
 #[derive(


### PR DESCRIPTION
- Permissionless harvest feature (Audit by Offside Labs and OtterSec) 
- Block reward_user_once by default. Allow delegate_authority to sign  reward_user_once (Audit by Offside Labs)