### PR TITLE
Release 1.6.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "farms"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/kfarms/Cargo.toml
+++ b/programs/kfarms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "farms"
 description = "Kamino Farms"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 license = "BUSL-1.1"
 publish = false

--- a/programs/kfarms/src/farm_operations.rs
+++ b/programs/kfarms/src/farm_operations.rs
@@ -395,6 +395,7 @@ pub fn initialize_user(
 
     user_state.rewards_tally_scaled = [0; MAX_REWARDS_TOKENS];
     user_state.rewards_issued_unclaimed = [0; MAX_REWARDS_TOKENS];
+    user_state.rewards_issued_cumulative = [0; MAX_REWARDS_TOKENS];
     user_state.active_stake_scaled = 0;
     user_state.last_claim_ts = [ts; MAX_REWARDS_TOKENS];
 
@@ -661,6 +662,8 @@ pub fn user_refresh_reward(
     user_state.set_rewards_tally_decimal(reward_index, new_reward_tally);
 
     user_state.rewards_issued_unclaimed[reward_index] += reward;
+    user_state.rewards_issued_cumulative[reward_index] =
+        user_state.rewards_issued_cumulative[reward_index].saturating_add(reward);
 
     Ok(())
 }
@@ -733,8 +736,13 @@ pub fn reward_user_once(
     amount: u64,
 ) -> Result<()> {
     farm_state.reward_infos[reward_index as usize].rewards_issued_unclaimed += amount;
-    farm_state.reward_infos[reward_index as usize].rewards_issued_cumulative += amount;
+    farm_state.reward_infos[reward_index as usize].rewards_issued_cumulative = farm_state
+        .reward_infos[reward_index as usize]
+        .rewards_issued_cumulative
+        .saturating_add(amount);
     user_state.rewards_issued_unclaimed[reward_index as usize] += amount;
+    user_state.rewards_issued_cumulative[reward_index as usize] =
+        user_state.rewards_issued_cumulative[reward_index as usize].saturating_add(amount);
     Ok(())
 }
 

--- a/programs/kfarms/src/handlers/handler_reward_user_once.rs
+++ b/programs/kfarms/src/handlers/handler_reward_user_once.rs
@@ -5,7 +5,17 @@ use crate::{
     FarmState,
 };
 
-pub fn process(ctx: Context<RewardUserOnce>, reward_index: u64, amount: u64) -> Result<()> {
+
+
+
+
+
+pub fn process(
+    ctx: Context<RewardUserOnce>,
+    reward_index: u64,
+    amount: u64,
+    expected_reward_issued_unclaimed: u64,
+) -> Result<()> {
     check_remaining_accounts(&ctx)?;
 
     let mut farm_state = ctx.accounts.farm_state.load_mut()?;
@@ -15,6 +25,12 @@ pub fn process(ctx: Context<RewardUserOnce>, reward_index: u64, amount: u64) -> 
         farm_state.is_reward_user_once_enabled,
         1,
         FarmError::RewardUserOnceFeatureDisabled
+    );
+
+    require_eq!(
+        user_state.rewards_issued_unclaimed[reward_index as usize],
+        expected_reward_issued_unclaimed,
+        FarmError::CurrentRewardIssuedUnclaimedMismatch
     );
 
     farm_operations::reward_user_once(&mut farm_state, &mut user_state, reward_index, amount)?;

--- a/programs/kfarms/src/lib.rs
+++ b/programs/kfarms/src/lib.rs
@@ -88,8 +88,14 @@ pub mod farms {
         ctx: Context<RewardUserOnce>,
         reward_index: u64,
         amount: u64,
+        expected_reward_issued_unclaimed: u64,
     ) -> Result<()> {
-        handler_reward_user_once::process(ctx, reward_index, amount)
+        handler_reward_user_once::process(
+            ctx,
+            reward_index,
+            amount,
+            expected_reward_issued_unclaimed,
+        )
     }
 
     pub fn refresh_farm(ctx: Context<RefreshFarm>) -> Result<()> {
@@ -378,6 +384,9 @@ pub enum FarmError {
    
     #[msg("Harvesting is not permissionless, payer does not match user state owner")]
     HarvestingNotPermissionlessPayerMismatch,
+   
+    #[msg("Current reward issued unclaimed does not match expected value")]
+    CurrentRewardIssuedUnclaimedMismatch,
 }
 
 impl From<DecimalError> for FarmError {

--- a/programs/kfarms/src/state.rs
+++ b/programs/kfarms/src/state.rs
@@ -534,7 +534,13 @@ pub struct UserState {
 
     pub last_stake_ts: u64,
 
-    pub _padding_1: [u64; 50],
+
+
+
+
+    pub rewards_issued_cumulative: [u64; MAX_REWARDS_TOKENS],
+
+    pub _padding_1: [u64; 40],
 }
 
 impl UserState {
@@ -593,7 +599,9 @@ impl Default for UserState {
             bump: 0,
             delegatee: Pubkey::default(),
             last_stake_ts: 0,
-            _padding_1: [0; 50],
+
+            rewards_issued_cumulative: [0; MAX_REWARDS_TOKENS],
+            _padding_1: [0; 40],
         }
     }
 }


### PR DESCRIPTION
- Add rewards_issued_cumulative at the userState level
- reward_user_once requires expected_reward_issued_unclaimed to match  user_state.rewards_issued_unclaimed